### PR TITLE
ci: add MSRV verification job for Rust 1.75.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,22 @@ jobs:
       - name: Run doc tests
         run: make test-doc
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust 1.75.0
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.75.0"
+
+      - name: Build
+        run: make build
+
+      - name: Run tests
+        run: make test
+
   wasm:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Closes #14

Add a dedicated `msrv` CI job that installs Rust 1.75.0 (matching `clippy.toml`) and runs `make build && make test` to verify the MSRV claim holds.

## Test plan

- [x] CI workflow syntax is valid YAML
- [ ] MSRV job passes on CI