### PR TITLE
Fix workspace deps for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ repository = "https://github.com/LeakIX/ironhtml"
 readme = "README.md"
 
 [workspace.dependencies]
-ironhtml-elements = { path = "crates/ironhtml-elements" }
-ironhtml-attributes = { path = "crates/ironhtml-attributes" }
-ironhtml = { path = "crates/ironhtml" }
-ironhtml-macro = { path = "crates/ironhtml-macro" }
-ironhtml-bootstrap = { path = "crates/ironhtml-bootstrap" }
+ironhtml-elements = { version = "1", path = "crates/ironhtml-elements" }
+ironhtml-attributes = { version = "1", path = "crates/ironhtml-attributes" }
+ironhtml = { version = "1", path = "crates/ironhtml" }
+ironhtml-macro = { version = "1", path = "crates/ironhtml-macro" }
+ironhtml-bootstrap = { version = "1", path = "crates/ironhtml-bootstrap" }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "parsing", "extra-traits"] }

--- a/crates/ironhtml-macro/Cargo.toml
+++ b/crates/ironhtml-macro/Cargo.toml
@@ -20,7 +20,3 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
-
-[dev-dependencies]
-ironhtml.workspace = true
-ironhtml-elements.workspace = true


### PR DESCRIPTION
## Summary

- Add `version = "1"` to all workspace dependency declarations (required by `cargo publish`)
- Remove unused dev-dependencies from ironhtml-macro (ironhtml, ironhtml-elements had 0 doc tests)

## Verification

```
cargo publish -p ironhtml-elements --dry-run --allow-dirty  # OK
cargo publish -p ironhtml-attributes --dry-run --allow-dirty  # OK
cargo publish -p ironhtml-macro --dry-run --allow-dirty  # OK
```

The remaining crates (parser, ironhtml, bootstrap) can't be dry-run locally since their deps aren't on crates.io yet, but `make publish` handles this by publishing in dependency order with 30s delays.