### PR TITLE
fix: format deny.toml with taplo

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,12 +7,12 @@ unmaintained = "warn"
 
 [licenses]
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "Unicode-3.0",
-    "ISC",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
+  "MIT",
+  "Apache-2.0",
+  "Unicode-3.0",
+  "ISC",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

- Fix taplo formatting in `deny.toml` (4-space → 2-space array indentation)

## Test plan

- [ ] CI lint job passes (taplo format --check)